### PR TITLE
ci: override container user

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: ghcr.io/visualon/renovate:38.142.0
+    container: 
+      image: ghcr.io/visualon/renovate:38.142.0
+      # github hosted runners are running as `1001:127` (ubuntu:docker)
+      options: -u 1001:0 --group-add 1001 --group-add 12021 --group-add 127
 
     strategy:
       matrix:


### PR DESCRIPTION
GitHub hosted runners are running as `1001:127`